### PR TITLE
Quote special characters in map-keys for use in Regexp

### DIFF
--- a/bulk-replace.js
+++ b/bulk-replace.js
@@ -1,7 +1,9 @@
+var quotemeta = require("quotemeta");
+
 module.exports = function(str, regex, map) {
     if (arguments.length === 2) {
         map = regex;
-        regex = new RegExp(Object.keys(map).join("|"), "ig");
+        regex = new RegExp(Object.keys(map).map(quotemeta).join("|"), "ig");
     }
 
     return str.replace(regex, function(all) {

--- a/package.json
+++ b/package.json
@@ -18,5 +18,8 @@
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/jeresig/node-bulk-replace/issues"
+  },
+  "dependencies": {
+    "quotemeta": "0.0.0"
   }
 }

--- a/testSpecialChars.js
+++ b/testSpecialChars.js
@@ -1,0 +1,15 @@
+var assert = require("assert");
+var bulkReplace = require("./bulk-replace");
+
+var test = {
+    "{": "}",
+    "}": "{",
+    "|": ";"
+};
+
+var str = "}{|";
+var expected = "{};";
+
+assert.equal(bulkReplace(str, test), expected);
+
+console.log("OK");


### PR DESCRIPTION
bulkReplace currently does not work, if only a map is provided, and the keys of the map contain characters that have special meanings in regular expressions. This patch escapes the keys using the "quotemeta" module (which is a very small module).  
